### PR TITLE
status is not a valid option on mac

### DIFF
--- a/utils
+++ b/utils
@@ -7,5 +7,5 @@ new_env() {
 }
 
 random() {
-  dd if=/dev/urandom bs=1 count=6 status=none | base64
+  dd if=/dev/urandom bs=1 count=6 2>/dev/null | base64
 }


### PR DESCRIPTION
dd implementation on mac doesn't support the status flag/option so, assuming hiding std err output is the purpose of the status=none..
